### PR TITLE
Fix setting vsync mechanism to NVIDIA's "Hope for the best" not disabling useHorribleHack

### DIFF
--- a/plugins/platforms/x11/standalone/glxbackend.cpp
+++ b/plugins/platforms/x11/standalone/glxbackend.cpp
@@ -244,6 +244,7 @@ void GlxBackend::init()
       case 1:
         useWaitSync=false;
         hopeBest=true;
+        useHorribleHack=false;
         break;
       case 2:
         useWaitSync=true;


### PR DESCRIPTION
useHorribleHack is always enabled when nvidia driver version is higher than 435, even when setting the mechanism to "hope for the best" manually. This patch essentially disables useHorribleHack if vsync mechanism is set to "hope for the best" to fix certain performance regressions.