### PR TITLE
Update NixOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ use the Arch Linux instructions. Manjaro has updated to Plasma 5.20.
 
 ## NixOS
 
-check out pasqui23's [kwin-ll](https://github.com/pasqui23/nixpkgs/tree/kwin-ll) branch.
-
-please note that this is an old version.
+[an overlay and binary cache](https://github.com/InternetUnexplorer/kwin-lowlatency-overlay) are available, courtesy of InternetUnexplorer.
 
 ## openSUSE Leap and Tumbleweed
 


### PR DESCRIPTION
The current installation instructions for NixOS suggest using pasqui23's [kwin-ll](https://github.com/pasqui23/nixpkgs/tree/kwin-ll) branch, which is several months out of date by now.

After making [this PR](https://github.com/NixOS/nixpkgs/pull/108987) to add `kwin-lowlatency` to upstream, the maintainers said that an overlay is probably the best way to go, so I made [InternetUnexplorer/kwin-lowlatency-overlay](https://github.com/InternetUnexplorer/kwin-lowlatency-overlay). I also set up a binary cache using Cachix, although I haven't had a chance to test it yet.

While I can't make any guarantees, I plan on keeping it up-to-date for the foreseeable future. And since it's already much more up-to-date (and significantly easier to maintain) than the currently listed installation method, I thought it might make sense to make it the new installation method.